### PR TITLE
v0.0.2 version bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 2023-02-?? - Support the filter of weight
+## v0.0.2 - 2023-02-15 - Support the filter of weight
 
 * Added filter support with type "weighted_shuffle"
 

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -13,7 +13,7 @@ from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class EdgeCenterClientException(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2023-02-15 - Support the filter of weight

* Added filter support with type "weighted_shuffle"

/cc https://github.com/octodns/octodns-edgecenter/pull/3 @mjekson