### PR TITLE
Added option 'exclude_disabled' to filter disabled records

### DIFF
--- a/tests/config/un.test.yaml
+++ b/tests/config/un.test.yaml
@@ -39,7 +39,7 @@
     - pool: weight
   ttl: 300
   type: CNAME
-  value: cl-dabdb3fc.edgecdn.ru.
+  value: cl-dabdb1fc.edgecdn.ru.
 01.img:
   ttl: 300
   type: CNAME

--- a/tests/fixtures/edgecenter-records.json
+++ b/tests/fixtures/edgecenter-records.json
@@ -423,6 +423,25 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "disabled.unit.tests",
+            "type": "A",
+            "ttl": 300,
+            "resource_records": [
+                {
+                    "enabled": true,
+                    "content": [
+                        "1.2.3.4"
+                    ]
+                },
+                {
+                    "enabled": false,
+                    "content": [
+                        "4.3.2.1"
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Firstly, sorting has been added for `defaults`. This solves the problem when two different plugins with support weighted records choose different value for the weighted CNAME record.

Second. I added an option `exclude_disabled` to filter rrset that have `ebabled: false`