### PR TITLE
Release 0.0.3 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.3 - 2023-??-?? -
+## v0.0.3 - 2025-01-23 - Support the ROOT
 
 * Add SUPPORTS_ROOT_NS to enable mangement of root NS records
 

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.2'
+__version__ = __VERSION__ = '0.0.3'
 
 
 class EdgeCenterClientException(ProviderException):


### PR DESCRIPTION
## v0.0.3 - 2025-01-23 - Support the ROOT

* Add SUPPORTS_ROOT_NS to enable mangement of root NS records

/cc Fixes https://github.com/octodns/octodns-edgecenter/issues/34 @akiryushin