### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:
 

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.3'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class EdgeCenterClientException(ProviderException):


### PR DESCRIPTION
## v1.0.0 - 2025-05-03 - Long overdue 1.0

Noteworthy Changes:

* Complete removal of SPF record support, records should be transitioned to TXT
  values before updating to this version.
Changes:
* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x