### PR TITLE
Change order of filters

### DIFF
--- a/.changelog/37f1015d724540088ef700c4e9941323.md
+++ b/.changelog/37f1015d724540088ef700c4e9941323.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Changed the order of filters to the one used in EdgeCenter DNS API

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -505,12 +505,12 @@ class _BaseProvider(BaseProvider):
         if "geodns" in types and "is_healthy" in types:
             want_filters = 4
             want_types = enumerate(
-                ["geodns", "default", "first_n", "is_healthy"]
+                ["is_healthy", "geodns", "default", "first_n"]
             )
         elif "weighted_shuffle" in types and "is_healthy" in types:
             want_filters = 3
             want_types = enumerate(
-                ["weighted_shuffle", "first_n", "is_healthy"]
+                ["is_healthy", "weighted_shuffle", "first_n"]
             )
         elif "geodns" in types:
             want_filters = 3
@@ -676,7 +676,7 @@ class _BaseProvider(BaseProvider):
         records = sorted(records, key=lambda x: (x["content"]))
 
         if record.octodns.get("healthcheck"):
-            filters = [*filters, *self.is_healthy_filters]
+            filters = [*self.is_healthy_filters, *filters]
             failover_data = self._params_for_failover(record)
             if failover_data:  # pragma: no branch
                 extra["meta"] = {"failover": failover_data}
@@ -707,7 +707,7 @@ class _BaseProvider(BaseProvider):
             records = sorted(records, key=lambda x: (x["content"]))
 
             if record.octodns.get("healthcheck"):
-                filters = [*filters, *self.is_healthy_filters]
+                filters = [*self.is_healthy_filters, *filters]
                 failover_data = self._params_for_failover(record)
                 if failover_data:  # pragma: no branch
                     extra["meta"] = {"failover": failover_data}

--- a/tests/fixtures/edgecenter-no-changes-failover.json
+++ b/tests/fixtures/edgecenter-no-changes-failover.json
@@ -14,15 +14,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -73,15 +73,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -133,15 +133,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -178,15 +178,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -254,15 +254,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -324,15 +324,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -382,15 +382,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -440,15 +440,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -490,15 +490,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -559,15 +559,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -653,15 +653,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -735,15 +735,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -810,15 +810,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -884,15 +884,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -983,15 +983,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -1036,6 +1036,10 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "geodns"
                 },
                 {
@@ -1045,10 +1049,7 @@
                 },
                 {
                     "type": "first_n",
-                    "limit": 1},
-                {
-                    "type": "is_healthy",
-                    "strict": false
+                    "limit": 1
                 }
             ],
             "resource_records": [
@@ -1168,12 +1169,12 @@
             },
             "filters": [
                 {
-                    "limit": 1,
-                    "type": "first_n"
-                },
-                {
                     "type": "is_healthy",
                     "strict": false
+                },
+                {
+                    "limit": 1,
+                    "type": "first_n"
                 },
                 {
                     "type": "weighted_shuffle"

--- a/tests/fixtures/edgecenter-records-failover.json
+++ b/tests/fixtures/edgecenter-records-failover.json
@@ -14,15 +14,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -73,15 +73,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -133,15 +133,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -178,15 +178,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -254,15 +254,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -324,15 +324,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -382,15 +382,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -440,15 +440,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -490,15 +490,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -559,15 +559,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -653,15 +653,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -735,15 +735,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -810,15 +810,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -884,15 +884,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -983,15 +983,15 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "weighted_shuffle"
                 },
                 {
                     "limit": 1,
                     "type": "first_n"
-                },
-                {
-                    "type": "is_healthy",
-                    "strict": false
                 }
             ],
             "resource_records": [
@@ -1036,6 +1036,10 @@
             },
             "filters": [
                 {
+                    "type": "is_healthy",
+                    "strict": false
+                },
+                {
                     "type": "geodns"
                 },
                 {
@@ -1045,10 +1049,7 @@
                 },
                 {
                     "type": "first_n",
-                    "limit": 1},
-                {
-                    "type": "is_healthy",
-                    "strict": false
+                    "limit": 1
                 }
             ],
             "resource_records": [

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -136,7 +136,7 @@ class TestEdgeCenterProvider(TestCase):
             changes = self.expected.changes(zone, provider)
             self.assertEqual(0, len(changes))
 
-        # TC: 4 create (dynamic) + 1 removed + 7 modified
+        # TC: 3 create (dynamic) + 1 removed + 7 modified
         with requests_mock() as mock:
             base = "https://api.edgecenter.ru/dns/v2/zones/unit.tests/rrsets"
             with open("tests/fixtures/edgecenter-records.json") as fh:
@@ -977,8 +977,8 @@ class TestEdgeCenterProviderFailover(TestCase):
                             "type": "A",
                             "ttl": 60,
                             "filters": [
-                                *provider.weighted_shuffle_filters,
                                 *provider.is_healthy_filters,
+                                *provider.weighted_shuffle_filters,
                             ],
                             "resource_records": [{"content": ["7.7.7.7"]}],
                         }
@@ -1282,8 +1282,8 @@ class TestEdgeCenterProviderFailover(TestCase):
                     data={
                         "ttl": 300,
                         "filters": [
-                            *provider.weighted_shuffle_filters,
                             *provider.is_healthy_filters,
+                            *provider.weighted_shuffle_filters,
                         ],
                         "meta": failover_tcp_meta,
                         "resource_records": [
@@ -1299,8 +1299,8 @@ class TestEdgeCenterProviderFailover(TestCase):
                     data={
                         "ttl": 300,
                         "filters": [
-                            *provider.weighted_shuffle_filters,
                             *provider.is_healthy_filters,
+                            *provider.weighted_shuffle_filters,
                         ],
                         "meta": failover_udp_meta,
                         "resource_records": [
@@ -1325,8 +1325,8 @@ class TestEdgeCenterProviderFailover(TestCase):
                     data={
                         "ttl": 300,
                         "filters": [
-                            *provider.weighted_shuffle_filters,
                             *provider.is_healthy_filters,
+                            *provider.weighted_shuffle_filters,
                         ],
                         "meta": failover_icmp_meta,
                         "resource_records": [
@@ -1345,8 +1345,8 @@ class TestEdgeCenterProviderFailover(TestCase):
                     data={
                         "ttl": 300,
                         "filters": [
-                            *provider.weighted_shuffle_filters,
                             *provider.is_healthy_filters,
+                            *provider.weighted_shuffle_filters,
                         ],
                         "meta": failover_http_meta,
                         "resource_records": [
@@ -1370,8 +1370,8 @@ class TestEdgeCenterProviderFailover(TestCase):
                     data={
                         "ttl": 300,
                         "filters": [
-                            *provider.weighted_shuffle_filters,
                             *provider.is_healthy_filters,
+                            *provider.weighted_shuffle_filters,
                         ],
                         "meta": failover_https_meta,
                         "resource_records": [


### PR DESCRIPTION
Changed the order of filters to the one used in EdgeCenter DNS API

The valid lists of filters (taking into account the order) are:
* ["is_healthy", "geodns", "default", "first_n"]
* ["is_healthy", "weighted_shuffle", "first_n"]
* ["geodns", "default", "first_n"]
* ["weighted_shuffle", "first_n"]