### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/2988ad618281444eb5e4d33390eff4ca.md
+++ b/.changelog/2988ad618281444eb5e4d33390eff4ca.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/3293e1e67c324eb69f8c91698941f1ac.md
+++ b/.changelog/3293e1e67c324eb69f8c91698941f1ac.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/37f1015d724540088ef700c4e9941323.md
+++ b/.changelog/37f1015d724540088ef700c4e9941323.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Changed the order of filters to the one used in EdgeCenter DNS API

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/46c3d657296f41c8980c81e72762f77a.md
+++ b/.changelog/46c3d657296f41c8980c81e72762f77a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/4f7c1222831d48b0bf0e1fea5ed32e2b.md
+++ b/.changelog/4f7c1222831d48b0bf0e1fea5ed32e2b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/500d571540fc4ce98d63492ac1cf5451.md
+++ b/.changelog/500d571540fc4ce98d63492ac1cf5451.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7936b705752b49b18ea4c0620f6a3374.md
+++ b/.changelog/7936b705752b49b18ea4c0620f6a3374.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/b8e544966c5e4fa08ea334b635096069.md
+++ b/.changelog/b8e544966c5e4fa08ea334b635096069.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/e4563730dee246ed9bf79a644ed13953.md
+++ b/.changelog/e4563730dee246ed9bf79a644ed13953.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Changed the order of filters to the one used in EdgeCenter DNS API - [#40](https://github.com/octodns/octodns-edgecenter/pull/40)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#39](https://github.com/octodns/octodns-edgecenter/pull/39)
+
 ## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 class EdgeCenterClientException(ProviderException):


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Changed the order of filters to the one used in EdgeCenter DNS API - [#40](https://github.com/octodns/octodns-edgecenter/pull/40)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#39](https://github.com/octodns/octodns-edgecenter/pull/39)

