### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/22037576f7f748c2ba76c1d468d60684.md
+++ b/.changelog/22037576f7f748c2ba76c1d468d60684.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -153,7 +153,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -24,7 +24,9 @@ from octodns_edgecenter import (
 
 class TestEdgeCenterProvider(TestCase):
     expected = Zone("unit.tests.", [])
-    source = YamlProvider("test", join(dirname(__file__), "config"))
+    source = YamlProvider(
+        "test", join(dirname(__file__), "config"), escaped_semicolons=False
+    )
     source.populate(expected)
 
     default_filters = [
@@ -700,7 +702,9 @@ class TestEdgeCenterProvider(TestCase):
 
 class TestEdgeCenterProviderWeighted(TestCase):
     expected = Zone("un.test.", [])
-    source = YamlProvider("test2", join(dirname(__file__), "config"))
+    source = YamlProvider(
+        "test2", join(dirname(__file__), "config"), escaped_semicolons=False
+    )
     source.populate(expected)
 
     weighted_shuffle_filters = [
@@ -907,7 +911,11 @@ class TestEdgeCenterProviderWeighted(TestCase):
 
 class TestEdgeCenterProviderFailover(TestCase):
     expected = Zone("failover.test.", [])
-    source = YamlProvider("test_failover", join(dirname(__file__), "config"))
+    source = YamlProvider(
+        "test_failover",
+        join(dirname(__file__), "config"),
+        escaped_semicolons=False,
+    )
     source.populate(expected)
 
     def test_populate(self):


### PR DESCRIPTION
YamlProvider is going to default to escaped_semicolons=False in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419