### PR TITLE
Fix import crash on filters-only meta; add RR meta passthrough

### DIFF
--- a/.changelog/15204ab2296447678ecab4147dd9353b.md
+++ b/.changelog/15204ab2296447678ecab4147dd9353b.md
@@ -2,3 +2,4 @@
 type: minor
 ---
 Add support for filters-only meta and RR meta pass-through
+   * NOTE: extra care should be taken to review changes on records with custom meta, See EdgeCenter RR meta passthrough in the README for more information.

--- a/.changelog/15204ab2296447678ecab4147dd9353b.md
+++ b/.changelog/15204ab2296447678ecab4147dd9353b.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add support for filters-only meta and RR meta pass-through

--- a/README.md
+++ b/README.md
@@ -60,6 +60,37 @@ Supports A, AAAA, NS, MX, TXT, SRV, CNAME, and PTR
 
 Supports dynamic records.
 
+#### EdgeCenter RR meta passthrough
+
+EdgeCenter RR meta keys that octoDNS dynamic does not model (`asn`, `ip`,
+`latlong`, `notes`, `regions`, and others outside geo/weight/default/backup)
+can be preserved in YAML under provider-specific passthrough:
+
+```yaml
+octodns:
+  edgecenter:
+    resource_record_meta:
+      - value: 2.2.2.2
+        meta:
+          regions: [ru-lug]
+          notes: set in EdgeCenter UI
+```
+
+On sync, passthrough meta is restored to the API by matching `value` to the
+RR content (CNAME targets are stored with a trailing dot, matching octoDNS
+dynamic values).
+
+**YAML is the source of truth.** Extra changes now compare the full API
+payload, not just failover settings. If meta exists in EdgeCenter (for example
+set in the UI) but is not represented in your config — including passthrough
+entries — `octodns-sync` may plan an update that removes it on apply.
+
+Records with EdgeCenter `filters` but only unsupported RR meta (for example
+`asn` or `regions` without geo, weight, default, or backup on any RR) import
+as plain `values`/`value` records instead of failing. Filters and that meta are
+not preserved on import. Syncing such a record may flatten server-side steering
+into a plain multi-value record.
+
 #### Filters
 
 Supports filter weight of records type A, AAAA, and CNAME (weighted_shuffle)

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -2,6 +2,7 @@
 #
 #
 
+import copy
 import http
 import logging
 import urllib.parse
@@ -198,24 +199,33 @@ class _BaseProvider(BaseProvider):
     def _supported_dynamic_meta(meta):
         return bool(set(meta.keys()) & _BaseProvider.SUPPORTED_DYNAMIC_META)
 
+    @classmethod
+    def _passthrough_meta(cls, meta):
+        passthrough = dict(meta)
+        for key in cls.SUPPORTED_DYNAMIC_META:
+            passthrough.pop(key, None)
+        return passthrough
+
     def _record_has_supported_dynamic_meta(self, record):
         for rr in record.get("resource_records", []):
-            if self._supported_dynamic_meta(rr.get("meta", {}) or {}):
+            if self._supported_dynamic_meta(rr.get("meta", {})):
                 return True
         return False
 
     def _extract_passthrough_rr_meta(self, record):
         entries = []
         for rr in record.get("resource_records", []):
-            meta = rr.get("meta", {}) or {}
-            passthrough = {
-                key: value
-                for key, value in meta.items()
-                if key not in self.SUPPORTED_DYNAMIC_META
-            }
+            content = rr.get("content") or []
+            if not content:
+                continue
+
+            passthrough = self._passthrough_meta(rr.get("meta", {}))
             if passthrough:
                 entries.append(
-                    {"value": rr["content"][0], "meta": passthrough}
+                    {
+                        "value": content[0],
+                        "meta": copy.deepcopy(passthrough),
+                    }
                 )
 
         if not entries:
@@ -245,9 +255,9 @@ class _BaseProvider(BaseProvider):
         )
         for entry in entries:
             value = entry.get("value")
-            meta = entry.get("meta") or {}
+            meta = entry.get("meta", {})
             if value is not None and meta:
-                result[value].append(meta.copy())
+                result[value].append(copy.deepcopy(meta))
         return result
 
     @staticmethod
@@ -262,8 +272,12 @@ class _BaseProvider(BaseProvider):
         geo_sets, pool_idx = dict(), 0
         pools = defaultdict(lambda: {"values": []})
         for rr in record["resource_records"]:
-            meta = rr.get("meta", {}) or {}
-            value = {"value": value_transform_fn(rr["content"][0])}
+            content = rr.get("content") or []
+            if not content:
+                continue
+
+            meta = rr.get("meta", {})
+            value = {"value": value_transform_fn(content[0])}
             countries = meta.get("countries", []) or []
             continents = meta.get("continents", []) or []
 
@@ -274,7 +288,7 @@ class _BaseProvider(BaseProvider):
             elif meta.get("weight", 0) > 0 or meta.get("backup"):
                 if meta.get("weight", 0) > 0:
                     value_weight = {
-                        "value": value_transform_fn(rr["content"][0]),
+                        "value": value_transform_fn(content[0]),
                         "weight": meta["weight"],
                     }
                     pools[self.WEIGHT_POOL]["values"].append(value_weight)
@@ -742,11 +756,16 @@ class _BaseProvider(BaseProvider):
                     if v in default_values:
                         default_values.remove(v)
 
-        # if default values doesn't match any pool values, then just add this
-        # values with no any meta
+        # values not assigned to any pool
         if default_values:
             for value in default_values:
-                records.append({"content": [value]})
+                rr_meta = self._next_passthrough_meta(
+                    value, passthrough_meta_by_value
+                )
+                record_data = {"content": [value]}
+                if rr_meta:
+                    record_data["meta"] = rr_meta
+                records.append(record_data)
 
         return records
 
@@ -856,10 +875,15 @@ class _BaseProvider(BaseProvider):
         }
 
     def _extra_changes_dynamic_needs_update(self, zone, record):
+        params_for = getattr(self, f"_params_for_{record._type}")
         for rrset in zone.records:
-            if rrset == record and self._params_for_failover(
-                rrset
-            ) != self._params_for_failover(record):
+            if rrset != record:
+                continue
+            if self._params_for_failover(rrset) != self._params_for_failover(
+                record
+            ):
+                return True
+            if params_for(rrset) != params_for(record):
                 return True
 
         return False

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -738,20 +738,25 @@ class _BaseProvider(BaseProvider):
                         for rr in records:
                             if v in rr["content"]:
                                 rr["meta"]["backup"] = True
+                                passthrough = self._next_passthrough_meta(
+                                    v, passthrough_meta_by_value
+                                )
+                                if passthrough:
+                                    rr["meta"].update(passthrough)
                                 break
                         else:
                             meta = {"backup": True}
                     elif pool_name == self.DEFAULT_POOL:  # pragma: no branch
                         meta = {"default": True}
 
-                    rr_meta = {
-                        **self._next_passthrough_meta(v, passthrough_meta_by_value),
-                        **meta,
-                    }
-                    if rr_meta:
+                    if meta:
+                        rr_meta = {
+                            **self._next_passthrough_meta(
+                                v, passthrough_meta_by_value
+                            ),
+                            **meta,
+                        }
                         records.append({"content": [v], "meta": rr_meta})
-                    else:
-                        records.append({"content": [v]})
 
                     if v in default_values:
                         default_values.remove(v)

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -148,6 +148,13 @@ class _BaseProvider(BaseProvider):
     DEFAULT_POOL = "other"
     WEIGHT_POOL = "weight"
     BACKUP_POOL = "backup"
+    SUPPORTED_DYNAMIC_META = {
+        "countries",
+        "continents",
+        "default",
+        "weight",
+        "backup",
+    }
 
     def __init__(self, id, api_url, auth_url, *args, **kwargs):
         token = kwargs.pop("token", None)
@@ -189,16 +196,66 @@ class _BaseProvider(BaseProvider):
 
     @staticmethod
     def _supported_dynamic_meta(meta):
-        return bool(
-            set(meta.keys())
-            & {"countries", "continents", "default", "weight", "backup"}
-        )
+        return bool(set(meta.keys()) & _BaseProvider.SUPPORTED_DYNAMIC_META)
 
     def _record_has_supported_dynamic_meta(self, record):
         for rr in record.get("resource_records", []):
             if self._supported_dynamic_meta(rr.get("meta", {}) or {}):
                 return True
         return False
+
+    def _extract_passthrough_rr_meta(self, record):
+        entries = []
+        for rr in record.get("resource_records", []):
+            meta = rr.get("meta", {}) or {}
+            passthrough = {
+                key: value
+                for key, value in meta.items()
+                if key not in self.SUPPORTED_DYNAMIC_META
+            }
+            if passthrough:
+                entries.append(
+                    {"value": rr["content"][0], "meta": passthrough}
+                )
+
+        if not entries:
+            return {}
+
+        return {"edgecenter": {"resource_record_meta": entries}}
+
+    @staticmethod
+    def _merge_octodns_metadata(*parts):
+        merged = {}
+        edgecenter = {}
+        for part in parts:
+            if not part:
+                continue
+            if "healthcheck" in part:
+                merged["healthcheck"] = part["healthcheck"]
+            part_edgecenter = part.get("edgecenter", {})
+            edgecenter.update(part_edgecenter)
+        if edgecenter:
+            merged["edgecenter"] = edgecenter
+        return merged
+
+    def _build_passthrough_meta_by_value(self, record):
+        result = defaultdict(list)
+        entries = (
+            record.octodns.get("edgecenter", {}).get("resource_record_meta", [])
+        )
+        for entry in entries:
+            value = entry.get("value")
+            meta = entry.get("meta") or {}
+            if value is not None and meta:
+                result[value].append(meta.copy())
+        return result
+
+    @staticmethod
+    def _next_passthrough_meta(value, passthrough_meta_by_value):
+        metas = passthrough_meta_by_value.get(value, [])
+        if metas:
+            return metas.pop(0)
+        return {}
 
     def _build_pools(self, record, value_transform_fn):
         defaults = []
@@ -369,7 +426,10 @@ class _BaseProvider(BaseProvider):
             "ttl": record["ttl"],
             "type": _type,
             "dynamic": {"pools": pools, "rules": rules},
-            "octodns": self._data_for_failover(record),
+            "octodns": self._merge_octodns_metadata(
+                self._data_for_failover(record),
+                self._extract_passthrough_rr_meta(record),
+            ),
             "value": self._add_dot_if_need(defaults[0]),
         }
 
@@ -391,7 +451,10 @@ class _BaseProvider(BaseProvider):
         ):
             pools, rules, defaults = self._data_for_dynamic(record)
             extra = {
-                "octodns": self._data_for_failover(record),
+                "octodns": self._merge_octodns_metadata(
+                    self._data_for_failover(record),
+                    self._extract_passthrough_rr_meta(record),
+                ),
                 "dynamic": {"pools": pools, "rules": rules},
                 "values": defaults,
             }
@@ -605,6 +668,9 @@ class _BaseProvider(BaseProvider):
         default_values = set(
             record.values if hasattr(record, "values") else [record.value]
         )
+        passthrough_meta_by_value = self._build_passthrough_meta_by_value(
+            record
+        )
 
         for rule in record.dynamic.rules:
             meta = dict()
@@ -630,7 +696,14 @@ class _BaseProvider(BaseProvider):
 
             for value in record.dynamic.pools[pool_name].data["values"]:
                 v = value["value"]
-                records.append({"content": [v], "meta": meta})
+                rr_meta = {
+                    **self._next_passthrough_meta(v, passthrough_meta_by_value),
+                    **meta,
+                }
+                record_data = {"content": [v]}
+                if rr_meta:
+                    record_data["meta"] = rr_meta
+                records.append(record_data)
 
                 if v in default_values:
                     default_values.remove(v)
@@ -657,8 +730,14 @@ class _BaseProvider(BaseProvider):
                     elif pool_name == self.DEFAULT_POOL:  # pragma: no branch
                         meta = {"default": True}
 
-                    if meta:
-                        records.append({"content": [v], "meta": meta})
+                    rr_meta = {
+                        **self._next_passthrough_meta(v, passthrough_meta_by_value),
+                        **meta,
+                    }
+                    if rr_meta:
+                        records.append({"content": [v], "meta": rr_meta})
+                    else:
+                        records.append({"content": [v]})
 
                     if v in default_values:
                         default_values.remove(v)

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -212,7 +212,9 @@ class _BaseProvider(BaseProvider):
                 return True
         return False
 
-    def _extract_passthrough_rr_meta(self, record):
+    def _extract_passthrough_rr_meta(
+        self, record, value_transform_fn=lambda x: x
+    ):
         entries = []
         for rr in record.get("resource_records", []):
             content = rr.get("content") or []
@@ -223,7 +225,7 @@ class _BaseProvider(BaseProvider):
             if passthrough:
                 entries.append(
                     {
-                        "value": content[0],
+                        "value": value_transform_fn(content[0]),
                         "meta": copy.deepcopy(passthrough),
                     }
                 )
@@ -250,8 +252,8 @@ class _BaseProvider(BaseProvider):
 
     def _build_passthrough_meta_by_value(self, record):
         result = defaultdict(list)
-        entries = (
-            record.octodns.get("edgecenter", {}).get("resource_record_meta", [])
+        entries = record.octodns.get("edgecenter", {}).get(
+            "resource_record_meta", []
         )
         for entry in entries:
             value = entry.get("value")
@@ -427,9 +429,9 @@ class _BaseProvider(BaseProvider):
     _data_for_PTR = _data_for_single
 
     def _data_for_CNAME(self, _type, record):
-        if record.get("filters") is None or not self._record_has_supported_dynamic_meta(
-            record
-        ):
+        if record.get(
+            "filters"
+        ) is None or not self._record_has_supported_dynamic_meta(record):
             return self._data_for_single(_type, record)
 
         pools, rules, defaults = self._data_for_dynamic(
@@ -442,7 +444,9 @@ class _BaseProvider(BaseProvider):
             "dynamic": {"pools": pools, "rules": rules},
             "octodns": self._merge_octodns_metadata(
                 self._data_for_failover(record),
-                self._extract_passthrough_rr_meta(record),
+                self._extract_passthrough_rr_meta(
+                    record, self._add_dot_if_need
+                ),
             ),
             "value": self._add_dot_if_need(defaults[0]),
         }
@@ -460,9 +464,9 @@ class _BaseProvider(BaseProvider):
         return {"ttl": record["ttl"], "type": _type, "value": values}
 
     def _data_for_multiple(self, _type, record):
-        if record.get("filters") is not None and self._record_has_supported_dynamic_meta(
-            record
-        ):
+        if record.get(
+            "filters"
+        ) is not None and self._record_has_supported_dynamic_meta(record):
             pools, rules, defaults = self._data_for_dynamic(record)
             extra = {
                 "octodns": self._merge_octodns_metadata(

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -187,6 +187,19 @@ class _BaseProvider(BaseProvider):
     def _add_dot_if_need(self, value):
         return f"{value}." if not value.endswith(".") else value
 
+    @staticmethod
+    def _supported_dynamic_meta(meta):
+        return bool(
+            set(meta.keys())
+            & {"countries", "continents", "default", "weight", "backup"}
+        )
+
+    def _record_has_supported_dynamic_meta(self, record):
+        for rr in record.get("resource_records", []):
+            if self._supported_dynamic_meta(rr.get("meta", {}) or {}):
+                return True
+        return False
+
     def _build_pools(self, record, value_transform_fn):
         defaults = []
         geo_sets, pool_idx = dict(), 0
@@ -343,7 +356,9 @@ class _BaseProvider(BaseProvider):
     _data_for_PTR = _data_for_single
 
     def _data_for_CNAME(self, _type, record):
-        if record.get("filters") is None:
+        if record.get("filters") is None or not self._record_has_supported_dynamic_meta(
+            record
+        ):
             return self._data_for_single(_type, record)
 
         pools, rules, defaults = self._data_for_dynamic(
@@ -371,7 +386,9 @@ class _BaseProvider(BaseProvider):
         return {"ttl": record["ttl"], "type": _type, "value": values}
 
     def _data_for_multiple(self, _type, record):
-        if record.get("filters") is not None:
+        if record.get("filters") is not None and self._record_has_supported_dynamic_meta(
+            record
+        ):
             pools, rules, defaults = self._data_for_dynamic(record)
             extra = {
                 "octodns": self._data_for_failover(record),

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -720,10 +720,7 @@ class TestEdgeCenterProvider(TestCase):
                             "regions": ["ru-pri"],
                         },
                     },
-                    {
-                        "content": ["2.2.2.2"],
-                        "meta": {"default": True},
-                    },
+                    {"content": ["2.2.2.2"], "meta": {"default": True}},
                 ],
             },
         )
@@ -731,7 +728,9 @@ class TestEdgeCenterProvider(TestCase):
         params = provider._params_for_A(record)
 
         first_rr = next(
-            rr for rr in params["resource_records"] if rr["content"] == ["1.1.1.1"]
+            rr
+            for rr in params["resource_records"]
+            if rr["content"] == ["1.1.1.1"]
         )
         self.assertEqual(["RU"], first_rr["meta"]["countries"])
         self.assertEqual([12345], first_rr["meta"]["asn"])
@@ -739,6 +738,344 @@ class TestEdgeCenterProvider(TestCase):
         self.assertEqual([27.988056, 86.925278], first_rr["meta"]["latlong"])
         self.assertEqual("passthrough", first_rr["meta"]["notes"])
         self.assertEqual(["ru-pri"], first_rr["meta"]["regions"])
+
+    def test_cname_passthrough_rr_meta_roundtrip(self):
+        provider = EdgeCenterProvider(
+            "test_id", token="token", strict_supports=False
+        )
+        zone = Zone("unit.tests.", [])
+        record_data = provider._data_for_CNAME(
+            "CNAME",
+            {
+                "name": "www.unit.tests.",
+                "type": "CNAME",
+                "ttl": 300,
+                "filters": self.default_filters,
+                "resource_records": [
+                    {
+                        "content": ["target.example.com"],
+                        "meta": {
+                            "countries": ["RU"],
+                            "regions": ["ru-msk"],
+                            "notes": "cname passthrough",
+                        },
+                    },
+                    {
+                        "content": ["fallback.example.com"],
+                        "meta": {"default": True},
+                    },
+                ],
+            },
+        )
+        record = Record.new(zone, "www", record_data, source=provider)
+        passthrough = record.octodns["edgecenter"]["resource_record_meta"][0]
+        self.assertEqual("target.example.com.", passthrough["value"])
+        self.assertEqual(["ru-msk"], passthrough["meta"]["regions"])
+
+        params = provider._params_for_CNAME(record)
+        target_rr = next(
+            rr
+            for rr in params["resource_records"]
+            if rr["content"] == ["target.example.com."]
+        )
+        self.assertEqual(["RU"], target_rr["meta"]["countries"])
+        self.assertEqual(["ru-msk"], target_rr["meta"]["regions"])
+        self.assertEqual("cname passthrough", target_rr["meta"]["notes"])
+
+    def test_extract_passthrough_skips_empty_content(self):
+        provider = EdgeCenterProvider("test_id", token="token")
+        result = provider._extract_passthrough_rr_meta(
+            {
+                "resource_records": [
+                    {"content": [], "meta": {"asn": [1]}},
+                    {"content": ["1.1.1.1"], "meta": {"asn": [2]}},
+                ]
+            }
+        )
+        self.assertEqual(
+            [{"value": "1.1.1.1", "meta": {"asn": [2]}}],
+            result["edgecenter"]["resource_record_meta"],
+        )
+
+    def test_build_passthrough_meta_by_value_skips_invalid_entries(self):
+        provider = EdgeCenterProvider("test_id", token="token")
+        zone = Zone("unit.tests.", [])
+        record = Record.new(
+            zone,
+            "",
+            {"ttl": 300, "type": "A", "value": "1.1.1.1"},
+            source=provider,
+        )
+        record.octodns = {
+            "edgecenter": {
+                "resource_record_meta": [
+                    {"value": None, "meta": {"asn": [1]}},
+                    {"value": "1.1.1.1", "meta": {}},
+                    {"value": "2.2.2.2", "meta": {"regions": ["ru-lug"]}},
+                ]
+            }
+        }
+        result = provider._build_passthrough_meta_by_value(record)
+        self.assertEqual([{"regions": ["ru-lug"]}], result["2.2.2.2"])
+
+    def test_build_pools_skips_empty_content(self):
+        provider = EdgeCenterProvider("test_id", token="token")
+        pools, geo_sets, defaults = provider._build_pools(
+            {
+                "resource_records": [
+                    {"content": [], "meta": {"default": True}},
+                    {"content": ["1.1.1.1"], "meta": {"default": True}},
+                ]
+            },
+            lambda x: x,
+        )
+        self.assertEqual(["1.1.1.1"], defaults)
+        self.assertEqual(
+            [{"value": "1.1.1.1"}], pools[provider.DEFAULT_POOL]["values"]
+        )
+
+    def test_params_for_geo_rule_without_meta(self):
+        provider = EdgeCenterProvider(
+            "test_id", token="token", strict_supports=False
+        )
+        zone = Zone("unit.tests.", [])
+        record = Record.new(
+            zone,
+            "",
+            {
+                "ttl": 300,
+                "type": "A",
+                "values": ["1.1.1.1"],
+                "dynamic": {
+                    "pools": {"pool-0": {"values": [{"value": "1.1.1.1"}]}},
+                    "rules": [{"pool": "pool-0"}],
+                },
+            },
+            source=provider,
+        )
+        params = provider._params_for_A(record)
+        self.assertEqual([{"content": ["1.1.1.1"]}], params["resource_records"])
+
+    def test_params_for_backup_passthrough_on_existing_rr(self):
+        provider = EdgeCenterProvider(
+            "test_id", token="token", strict_supports=False
+        )
+        zone = Zone("unit.tests.", [])
+        record = Record.new(
+            zone,
+            "",
+            {
+                "ttl": 300,
+                "type": "A",
+                "values": ["3.3.3.3"],
+                "dynamic": {
+                    "pools": {
+                        "backup": {
+                            "fallback": "other",
+                            "values": [{"value": "3.3.3.3"}],
+                        },
+                        "other": {
+                            "values": [
+                                {"value": "4.3.3.3"},
+                                {"value": "5.3.3.3"},
+                            ]
+                        },
+                        "weight": {
+                            "fallback": "backup",
+                            "values": [
+                                {"value": "3.3.3.3", "weight": 2},
+                                {"value": "1.3.3.3", "weight": 5},
+                            ],
+                        },
+                    },
+                    "rules": [{"pool": "weight"}],
+                },
+                "octodns": {
+                    "edgecenter": {
+                        "resource_record_meta": [
+                            {
+                                "value": "3.3.3.3",
+                                "meta": {"regions": ["ru-lug"]},
+                            },
+                            {
+                                "value": "3.3.3.3",
+                                "meta": {"notes": "backup passthrough"},
+                            },
+                        ]
+                    }
+                },
+            },
+            source=provider,
+        )
+        params = provider._params_for_A(record)
+        matching = [
+            rr
+            for rr in params["resource_records"]
+            if rr["content"] == ["3.3.3.3"]
+        ]
+        self.assertEqual(1, len(matching))
+        self.assertTrue(matching[0]["meta"]["backup"])
+        self.assertEqual(2, matching[0]["meta"]["weight"])
+        self.assertEqual(["ru-lug"], matching[0]["meta"]["regions"])
+        self.assertEqual("backup passthrough", matching[0]["meta"]["notes"])
+
+    def test_params_for_backup_passthrough_new_rr(self):
+        provider = EdgeCenterProvider(
+            "test_id", token="token", strict_supports=False
+        )
+        zone = Zone("unit.tests.", [])
+        record = Record.new(
+            zone,
+            "",
+            {
+                "ttl": 300,
+                "type": "A",
+                "values": ["1.1.1.1"],
+                "dynamic": {
+                    "pools": {
+                        "backup": {
+                            "fallback": "other",
+                            "values": [{"value": "7.7.7.7"}],
+                        },
+                        "other": {
+                            "values": [
+                                {"value": "4.3.3.3"},
+                                {"value": "5.3.3.3"},
+                            ]
+                        },
+                        "weight": {
+                            "fallback": "backup",
+                            "values": [
+                                {"value": "1.1.1.1", "weight": 5},
+                                {"value": "2.2.2.2", "weight": 1},
+                            ],
+                        },
+                    },
+                    "rules": [{"pool": "weight"}],
+                },
+                "octodns": {
+                    "edgecenter": {
+                        "resource_record_meta": [
+                            {
+                                "value": "7.7.7.7",
+                                "meta": {"regions": ["ru-don"]},
+                            }
+                        ]
+                    }
+                },
+            },
+            source=provider,
+        )
+        params = provider._params_for_A(record)
+        backup_rr = next(
+            rr
+            for rr in params["resource_records"]
+            if rr["content"] == ["7.7.7.7"]
+        )
+        self.assertTrue(backup_rr["meta"]["backup"])
+        self.assertEqual(["ru-don"], backup_rr["meta"]["regions"])
+
+    def test_data_for_dynamic_raises_when_no_pools(self):
+        provider = EdgeCenterProvider("test_id", token="token")
+        with self.assertRaises(RuntimeError):
+            provider._data_for_dynamic(
+                {
+                    "resource_records": [
+                        {"content": ["1.1.1.1"], "meta": {"countries": []}}
+                    ]
+                }
+            )
+
+    def test_extra_changes_dynamic_needs_update_failover(self):
+        provider = EdgeCenterProvider("test_id", token="token")
+        zone = Zone("unit.tests.", [])
+        base = {
+            "ttl": 300,
+            "type": "A",
+            "values": ["1.1.1.1"],
+            "dynamic": {
+                "pools": {
+                    "weight": {"values": [{"value": "1.1.1.1", "weight": 1}]}
+                },
+                "rules": [{"pool": "weight"}],
+            },
+        }
+        existing = Record.new(
+            zone,
+            "",
+            {
+                **base,
+                "octodns": {
+                    "healthcheck": {"port": 80, "protocol": "TCP"},
+                    "edgecenter": {
+                        "failover": {"frequency": 10, "timeout": 10}
+                    },
+                },
+            },
+            source=provider,
+        )
+        desired = Record.new(
+            zone,
+            "",
+            {
+                **base,
+                "octodns": {
+                    "healthcheck": {"port": 80, "protocol": "TCP"},
+                    "edgecenter": {
+                        "failover": {"frequency": 20, "timeout": 10}
+                    },
+                },
+            },
+            source=provider,
+        )
+        zone.add_record(existing)
+        self.assertTrue(
+            provider._extra_changes_dynamic_needs_update(zone, desired)
+        )
+
+    def test_extra_changes_dynamic_needs_update_passthrough(self):
+        provider = EdgeCenterProvider("test_id", token="token")
+        zone = Zone("unit.tests.", [])
+        base = {
+            "ttl": 300,
+            "type": "A",
+            "values": ["1.1.1.1"],
+            "dynamic": {
+                "pools": {
+                    "weight": {"values": [{"value": "1.1.1.1", "weight": 1}]}
+                },
+                "rules": [{"pool": "weight"}],
+            },
+            "octodns": {
+                "healthcheck": {"port": 80, "protocol": "TCP"},
+                "edgecenter": {"failover": {"frequency": 10, "timeout": 10}},
+            },
+        }
+        existing = Record.new(
+            zone,
+            "",
+            {
+                **base,
+                "octodns": {
+                    **base["octodns"],
+                    "edgecenter": {
+                        **base["octodns"]["edgecenter"],
+                        "resource_record_meta": [
+                            {
+                                "value": "1.1.1.1",
+                                "meta": {"regions": ["ru-lug"]},
+                            }
+                        ],
+                    },
+                },
+            },
+            source=provider,
+        )
+        desired = Record.new(zone, "", base, source=provider)
+        zone.add_record(existing)
+        self.assertTrue(
+            provider._extra_changes_dynamic_needs_update(zone, desired)
+        )
 
     def test_passthrough_meta_on_values_only_rr(self):
         provider = EdgeCenterProvider(
@@ -753,11 +1090,7 @@ class TestEdgeCenterProvider(TestCase):
                 "type": "A",
                 "values": ["1.1.1.1", "2.2.2.2"],
                 "dynamic": {
-                    "pools": {
-                        "other": {
-                            "values": [{"value": "1.1.1.1"}],
-                        }
-                    },
+                    "pools": {"other": {"values": [{"value": "1.1.1.1"}]}},
                     "rules": [{"pool": "other"}],
                 },
                 "octodns": {
@@ -775,7 +1108,9 @@ class TestEdgeCenterProvider(TestCase):
         )
         params = provider._params_for_A(record)
         second_rr = next(
-            rr for rr in params["resource_records"] if rr["content"] == ["2.2.2.2"]
+            rr
+            for rr in params["resource_records"]
+            if rr["content"] == ["2.2.2.2"]
         )
         self.assertEqual(["ru-lug", "ru-don"], second_rr["meta"]["regions"])
 

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -182,7 +182,7 @@ class TestEdgeCenterProvider(TestCase):
             self.assertEqual(1, len(zone.records))
             record = next(iter(zone.records))
             self.assertEqual("A", record._type)
-            self.assertIsNone(record.dynamic)
+            self.assertFalse(record.dynamic)
             self.assertEqual(["7.7.7.7"], record.values)
 
     def test_apply(self):
@@ -876,7 +876,7 @@ class TestEdgeCenterProviderWeighted(TestCase):
             self.assertEqual(1, len(zone.records))
             record = next(iter(zone.records))
             self.assertEqual("A", record._type)
-            self.assertIsNone(record.dynamic)
+            self.assertFalse(record.dynamic)
             self.assertEqual(["7.7.7.7"], record.values)
 
     def test_apply(self):
@@ -1076,7 +1076,7 @@ class TestEdgeCenterProviderFailover(TestCase):
             self.assertEqual(1, len(zone.records))
             record = next(iter(zone.records))
             self.assertEqual("A", record._type)
-            self.assertIsNone(record.dynamic)
+            self.assertFalse(record.dynamic)
             self.assertEqual(["7.7.7.7"], record.values)
 
     def test_apply(self):

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -696,6 +696,50 @@ class TestEdgeCenterProvider(TestCase):
         provider = EdgeCenterProvider("test_id", token="token")
         self.assertIsInstance(provider, _BaseProvider)
 
+    def test_dynamic_passthrough_rr_meta_roundtrip(self):
+        provider = EdgeCenterProvider(
+            "test_id", token="token", strict_supports=False
+        )
+        zone = Zone("unit.tests.", [])
+        record_data = provider._data_for_A(
+            "A",
+            {
+                "name": "unit.tests.",
+                "type": "A",
+                "ttl": 300,
+                "filters": self.default_filters,
+                "resource_records": [
+                    {
+                        "content": ["1.1.1.1"],
+                        "meta": {
+                            "countries": ["RU"],
+                            "asn": [12345],
+                            "ip": ["10.10.10.0/24"],
+                            "latlong": [27.988056, 86.925278],
+                            "notes": "passthrough",
+                            "regions": ["ru-pri"],
+                        },
+                    },
+                    {
+                        "content": ["2.2.2.2"],
+                        "meta": {"default": True},
+                    },
+                ],
+            },
+        )
+        record = Record.new(zone, "", record_data, source=provider)
+        params = provider._params_for_A(record)
+
+        first_rr = next(
+            rr for rr in params["resource_records"] if rr["content"] == ["1.1.1.1"]
+        )
+        self.assertEqual(["RU"], first_rr["meta"]["countries"])
+        self.assertEqual([12345], first_rr["meta"]["asn"])
+        self.assertEqual(["10.10.10.0/24"], first_rr["meta"]["ip"])
+        self.assertEqual([27.988056, 86.925278], first_rr["meta"]["latlong"])
+        self.assertEqual("passthrough", first_rr["meta"]["notes"])
+        self.assertEqual(["ru-pri"], first_rr["meta"]["regions"])
+
 
 class TestEdgeCenterProviderWeighted(TestCase):
     expected = Zone("un.test.", [])

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -178,15 +178,12 @@ class TestEdgeCenterProvider(TestCase):
             )
 
             zone = Zone("unit.tests.", [])
-            with self.assertRaises(RuntimeError) as ctx:
-                provider.populate(zone)
-
-            self.assertTrue(
-                str(ctx.exception).startswith(
-                    "filter is enabled, but no pools where built for"
-                ),
-                f"{ctx.exception} - is not start from desired text",
-            )
+            provider.populate(zone)
+            self.assertEqual(1, len(zone.records))
+            record = next(iter(zone.records))
+            self.assertEqual("A", record._type)
+            self.assertIsNone(record.dynamic)
+            self.assertEqual(["7.7.7.7"], record.values)
 
     def test_apply(self):
         provider = EdgeCenterProvider(
@@ -792,15 +789,12 @@ class TestEdgeCenterProviderWeighted(TestCase):
             )
 
             zone = Zone("un.test.", [])
-            with self.assertRaises(RuntimeError) as ctx:
-                provider.populate(zone)
-
-            self.assertTrue(
-                str(ctx.exception).startswith(
-                    "filter is enabled, but no pools where built for"
-                ),
-                f"{ctx.exception} - is not start from desired text",
-            )
+            provider.populate(zone)
+            self.assertEqual(1, len(zone.records))
+            record = next(iter(zone.records))
+            self.assertEqual("A", record._type)
+            self.assertIsNone(record.dynamic)
+            self.assertEqual(["7.7.7.7"], record.values)
 
     def test_apply(self):
         provider = EdgeCenterProvider(
@@ -995,15 +989,12 @@ class TestEdgeCenterProviderFailover(TestCase):
             )
 
             zone = Zone("failover.test.", [])
-            with self.assertRaises(RuntimeError) as ctx:
-                provider.populate(zone)
-
-            self.assertTrue(
-                str(ctx.exception).startswith(
-                    "filter is enabled, but no pools where built for"
-                ),
-                f"{ctx.exception} - is not start from desired text",
-            )
+            provider.populate(zone)
+            self.assertEqual(1, len(zone.records))
+            record = next(iter(zone.records))
+            self.assertEqual("A", record._type)
+            self.assertIsNone(record.dynamic)
+            self.assertEqual(["7.7.7.7"], record.values)
 
     def test_apply(self):
         provider = EdgeCenterProvider(

--- a/tests/test_octodns_provider_edgecenter.py
+++ b/tests/test_octodns_provider_edgecenter.py
@@ -740,6 +740,45 @@ class TestEdgeCenterProvider(TestCase):
         self.assertEqual("passthrough", first_rr["meta"]["notes"])
         self.assertEqual(["ru-pri"], first_rr["meta"]["regions"])
 
+    def test_passthrough_meta_on_values_only_rr(self):
+        provider = EdgeCenterProvider(
+            "test_id", token="token", strict_supports=False
+        )
+        zone = Zone("unit.tests.", [])
+        record = Record.new(
+            zone,
+            "",
+            {
+                "ttl": 300,
+                "type": "A",
+                "values": ["1.1.1.1", "2.2.2.2"],
+                "dynamic": {
+                    "pools": {
+                        "other": {
+                            "values": [{"value": "1.1.1.1"}],
+                        }
+                    },
+                    "rules": [{"pool": "other"}],
+                },
+                "octodns": {
+                    "edgecenter": {
+                        "resource_record_meta": [
+                            {
+                                "value": "2.2.2.2",
+                                "meta": {"regions": ["ru-lug", "ru-don"]},
+                            }
+                        ]
+                    }
+                },
+            },
+            source=provider,
+        )
+        params = provider._params_for_A(record)
+        second_rr = next(
+            rr for rr in params["resource_records"] if rr["content"] == ["2.2.2.2"]
+        )
+        self.assertEqual(["ru-lug", "ru-don"], second_rr["meta"]["regions"])
+
 
 class TestEdgeCenterProviderWeighted(TestCase):
     expected = Zone("un.test.", [])


### PR DESCRIPTION
Hey, @ross 
Only treat API records as octoDNS dynamic when at least one supported RR meta key is present: countries, continents, default, weight, backup. Records with filters but only unsupported meta (e.g. asn, ip, regions, notes) are imported as plain values/value instead of failing with "no pools were built".
Unsupported RR meta is stored under octodns.edgecenter.resource_record_meta (per value) and restored on sync. Supported meta still maps to dynamic.