### PR TITLE
Version 1.2.0 bump & changelog update

### DIFF
--- a/.changelog/15204ab2296447678ecab4147dd9353b.md
+++ b/.changelog/15204ab2296447678ecab4147dd9353b.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-Add support for filters-only meta and RR meta pass-through
-   * NOTE: extra care should be taken to review changes on records with custom meta, See EdgeCenter RR meta passthrough in the README for more information.

--- a/.changelog/22037576f7f748c2ba76c1d468d60684.md
+++ b/.changelog/22037576f7f748c2ba76c1d468d60684.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Explicit non-escaped semicolons for YamlProvider

--- a/.changelog/b26fbba80a954c068a2cd05aa4acf3e4.md
+++ b/.changelog/b26fbba80a954c068a2cd05aa4acf3e4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0 - 2026-05-31
+
+Minor:
+* Add support for filters-only meta and RR meta pass-through
+   * NOTE: extra care should be taken to review changes on records with custom meta, See EdgeCenter RR meta passthrough in the README for more information. - [#55](https://github.com/octodns/octodns-edgecenter/pull/55)
+
 ## 1.1.0 - 2026-04-03
 
 Minor:

--- a/octodns_edgecenter/__init__.py
+++ b/octodns_edgecenter/__init__.py
@@ -17,7 +17,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.2.0'
 
 
 class EdgeCenterClientException(ProviderException):


### PR DESCRIPTION
## 1.2.0 - 2026-05-31

Minor:
* Add support for filters-only meta and RR meta pass-through
   * NOTE: extra care should be taken to review changes on records with custom meta, See EdgeCenter RR meta passthrough in the README for more information. - [#55](https://github.com/octodns/octodns-edgecenter/pull/55)

